### PR TITLE
FIX(responsive): Responsividade do footer melhorada

### DIFF
--- a/src/components/footer/footer.css
+++ b/src/components/footer/footer.css
@@ -183,7 +183,7 @@
 	color: #e0e0e0;
 	margin-bottom: 20px;
 	font-size: 0.95rem;
-	text-align: center;
+	text-align: justify;
 }
 
 .social-links {
@@ -380,45 +380,59 @@
    RESPONSIVE DESIGN
    ============================================ */
 
-/* Tablets */
-@media (max-width: 768px) {
-	.footer-main {
-		padding: 40px 20px 30px;
-	}
-
+/* Small desktops / large tablets */
+@media (max-width: 1020px) {
 	.footer-main .footer-container {
-		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-		gap: 30px;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		grid-template-areas:
+			"about contact"
+			"social social";
 	}
 
-	.footer-section h3 {
-		font-size: 1.2rem;
-	}
-
-	.footer-bottom-content {
-		flex-direction: column;
+	.footer-section h3{
 		text-align: center;
+	}
+
+	.footer-section h3::after {
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	.footer-section.footer-about {
+		grid-area: about;
+	}
+
+	.footer-section.footer-contact {
+		grid-area: contact;
+	}
+
+	.footer-section.footer-social {
+		grid-area: social;
+		justify-self: center;
 	}
 
 	.social-links {
 		justify-content: center;
 	}
-
-	.developer-content {
-		flex-direction: column;
-		text-align: center;
-	}
 }
 
-/* Mobile */
-@media (max-width: 480px) {
+/* Tablets */
+@media (max-width: 768px) {
 	.footer-main {
 		padding: 30px 15px 20px;
 	}
 
 	.footer-main .footer-container {
 		grid-template-columns: 1fr;
+		grid-template-areas: none;
 		gap: 30px;
+	}
+
+	.footer-section.footer-about,
+	.footer-section.footer-contact,
+	.footer-section.footer-social {
+		grid-area: auto;
+		justify-self: stretch;
 	}
 
 	.footer-section {
@@ -431,11 +445,6 @@
 
 	.footer-section.footer-social p {
 		text-align: center;
-	}
-
-	.footer-section h3::after {
-		left: 50%;
-		transform: translateX(-50%);
 	}
 
 	.contact-list li {
@@ -454,10 +463,6 @@
 		display: none;
 	}
 
-	.social-links {
-		justify-content: center;
-	}
-
 	.footer-logo {
 		text-align: center;
 	}
@@ -471,7 +476,10 @@
 		text-align: center;
 		justify-content: center;
 	}
+}
 
+/* Mobile */
+@media (max-width: 480px) {
 	.developer-info {
 		flex-direction: column;
 		gap: 10px;


### PR DESCRIPTION
This pull request updates the responsive design and layout of the `footer` component's CSS to provide better structure and appearance across different screen sizes. The main changes reorganize the grid layout for small desktops, tablets, and mobile devices, and refine text alignment and section positioning for improved readability and consistency.

**Responsive layout improvements:**

* Redesigned the grid structure for `.footer-main .footer-container` at different breakpoints:
  - For screens up to 1020px, uses a two-column grid with named areas (`about`, `contact`, `social`) for better organization and alignment.
  - For screens up to 768px, switches to a single-column layout and resets grid areas for a stacked, mobile-friendly view.
  - Added a new breakpoint for screens up to 480px for mobile-specific adjustments.

* Adjusted section alignment and text formatting:
  - Changed `.footer-bottom-content` and `.developer-content` to be more flexible and centered on smaller screens. [[1]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL383-R437) [[2]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efR479-R482)
  - Updated `.footer-section h3` and its pseudo-element for better centering and visual consistency. [[1]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL383-R437) [[2]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL436-L440)

**Text alignment changes:**

* Changed `.footer-bottom-content` text alignment from `center` to `justify` for improved readability on wider screens.

**Cleanup and consolidation:**

* Removed redundant or duplicate CSS rules for `.social-links` and heading pseudo-elements, consolidating their logic under the new responsive structure. [[1]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL436-L440) [[2]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL457-L460) [[3]](diffhunk://#diff-f909a0a9595d491458a98f7d2acf5ea0902f54a0a918801205d718e0ad4f60efL383-R437)